### PR TITLE
Single test execution

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,4 @@
-== 2.0.0 /2015-03-09
+== 2.0.0 /2015-09-10
  * Completely rewritten execution engine
    * dropped Ruby 1.8.x, 1.9.x support, added 2.x
  * Rewritten configuration engine and new format for configuration files
@@ -6,6 +6,9 @@
  * Core separated from standard implementations
  * No database dependencies, no AR model. 
  * No more disk IO in unit tests
+ * pre3: 
+    * errors now affect the rutema exit code (before it was only test failures)
+    * single test execution works with expected relative paths
 
 == 1.3.0 /2012-11-28
 * remove most of the gem dependencies by not requiring parsers and reporters in the core

--- a/lib/rutema/application.rb
+++ b/lib/rutema/application.rb
@@ -13,10 +13,8 @@ module Rutema
       @configuration.reporters||={}
       @configuration.reporters[Rutema::Reporters::Console]||={:class=>Rutema::Reporters::Console, "silent"=>@silent} unless @bare
       @configuration.reporters[Rutema::Reporters::Summary]||={:class=>Rutema::Reporters::Summary, "silent"=>(@silent||@bare)}
-      Dir.chdir(File.dirname(@config_file)) do 
-        @engine=Rutema::Engine.new(@configuration)
-        application_flow
-      end
+      @engine=Rutema::Engine.new(@configuration)
+      application_flow
     end
     private
     def parse_command_line args

--- a/lib/rutema/core/engine.rb
+++ b/lib/rutema/core/engine.rb
@@ -26,7 +26,6 @@ module Rutema
       message("start")
       check,setup,teardown,tests=*parse(test_identifier)
       if tests.empty?
-        error(test_identifier,"Did not parse any tests succesfully")
         @dispatcher.exit
         raise RutemaError,"Did not parse any tests succesfully"
       else
@@ -49,7 +48,7 @@ module Rutema
         if @configuration.tests.include?(File.expand_path(test_identifier))
           specs<<parse_specification(File.expand_path(test_identifier))
         else
-          error(test_identifier,"Does not exist in the configuration")  
+          error(File.expand_path(test_identifier),"Does not exist in the configuration")  
         end
       else
         specs=parse_specifications(@configuration.tests)

--- a/lib/rutema/core/reporter.rb
+++ b/lib/rutema/core/reporter.rb
@@ -70,7 +70,7 @@ module Rutema
       end
       def update data
         if data[:error]
-          puts ">ERROR: #{data[:error]}" unless @mode=="off"
+          puts ">ERROR: #{data.fetch(:test,"")} #{data[:error]}" unless @mode=="off"
         elsif data[:test] 
           if data["phase"]
             puts ">#{data["phase"]} #{data[:test]}" unless @mode=="silent" || @mode=="off"
@@ -106,7 +106,7 @@ module Rutema
             puts specs.map{|spec| "  #{spec.name} - #{spec.filename}" if failures.include?(spec.name)}.compact.join("\n")
           end
         end
-        return failures.size
+        return failures.size+errors.size
       end
     end
   end

--- a/lib/rutema/version.rb
+++ b/lib/rutema/version.rb
@@ -3,7 +3,7 @@ module Rutema
   module Version
     MAJOR=2
     MINOR=0
-    TINY="0.pre2"
+    TINY="0.pre3"
     STRING=[ MAJOR, MINOR, TINY ].join( "." )
   end
 end

--- a/test/test_engine.rb
+++ b/test/test_engine.rb
@@ -58,7 +58,7 @@ module TestRutema
       assert_equal(9, MockReporter.updates)
       #test for a spec that is not in the config and re-entry
       assert_raise(Rutema::RutemaError) { engine.run("foo")}
-      assert_equal(3, MockReporter.updates)
+      assert_equal(2, MockReporter.updates)
     end
   end
 end


### PR DESCRIPTION
The working directory was set to the configuration file's directory for the whole rutema execution context.
This led to mismatch between test lists in the configuration and relative paths on the command line.

This PR fixes that and improves the error messages by including test identifiers and making paths absolute.