### PR TITLE
Refactor messaging to use types instead of hashes

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,8 @@
+== 2.0.0.pre6 /2015-09-25
+ * Switch the reporter interface to using types instead of hashes
+ * Fix Ruby deprecation warnings
+ * Reduced message output
+ * Console reporter now has a verbosity setting
 == 2.0.0.pre5 /2015-09-14
  * Add JUnit format reporter
  * The NUnit format is v3, which means it won't work for most CI plugins

--- a/examples/suites/rutema.rutema
+++ b/examples/suites/rutema.rutema
@@ -1,6 +1,7 @@
 require 'rake/file_list'
 configure do |cfg|
   cfg.import("../config/tools.rutema")
+  cfg.reporter={:class=>Rutema::Reporters::Console,"mode"=>"verbose"}
   cfg.tests=Rake::FileList["../specs/T0*.spec"].existing
   cfg.check="../specs/check.spec"
   cfg.setup="../specs/setup.spec"

--- a/lib/rutema/application.rb
+++ b/lib/rutema/application.rb
@@ -31,6 +31,7 @@ module Rutema
         #opt.on("--color","Adds color to the Console reporter") { @color=true}
         opt.on("-v", "--version","Displays the version") { $stdout.puts("rutema v#{Version::STRING}");exit 0 }
         opt.on("--help", "-h", "-?", "This text") { $stdout.puts opt; exit 0 }
+        opt.on("--debug", "-d", "Turn on debug messages") { $DEBUG=true }
         opt.on("You can provide a specification filename in order to run a single test")
         opt.parse!
         #and now the rest

--- a/lib/rutema/core/configuration.rb
+++ b/lib/rutema/core/configuration.rb
@@ -121,7 +121,7 @@
       #Checks if a path exists and raises a ConfigurationException if not
       def check_path path
         path=File.expand_path(path)
-        raise ConfigurationException,"#{path} does not exist" unless File.exists?(path)
+        raise ConfigurationException,"#{path} does not exist" unless File.exist?(path)
         return path
       end
       #Gives back a string of key=value,key=value for a hash
@@ -132,7 +132,7 @@
       end
 
       def full_path filename
-        return File.expand_path(filename) if File.exists?(filename)
+        return File.expand_path(filename) if File.exist?(filename)
         return filename
       end
     end
@@ -165,7 +165,7 @@
       # import("first.rutema")
       def import filename
         fnm = File.expand_path(filename)
-        if File.exists?(fnm)          
+        if File.exist?(fnm)          
           load_configuration(fnm)
         else
           raise ConfigurationException, "Import error: Can't find #{fnm}"

--- a/lib/rutema/core/engine.rb
+++ b/lib/rutema/core/engine.rb
@@ -104,7 +104,7 @@ module Rutema
         status=@runner.run(specification)["status"]
       else
         status=:not_executed
-        message(:test=>specification.name,:message=>"No scenario", :status=>status)
+        message(:test=>specification.name,:text=>"No scenario", :status=>status)
       end
       return status
     end

--- a/lib/rutema/core/engine.rb
+++ b/lib/rutema/core/engine.rb
@@ -138,6 +138,7 @@ module Rutema
     end
     
     def run!
+      puts "Running #{@streaming_reporters.size} streaming reporters" if $DEBUG
       @streaming_reporters.each {|r| r.run!}
       @thread=Thread.new do
         while true do
@@ -154,6 +155,7 @@ module Rutema
       Reporters::Summary.new(@configuration,self).report(specs,@collector.states,@collector.errors)
     end
     def exit
+      puts "Exiting main dispatcher" if $DEBUG
       if @thread
         flush
         @streaming_reporters.each {|r| r.exit}
@@ -162,6 +164,7 @@ module Rutema
     end
     private
     def flush
+      puts "Flushing queues" if $DEBUG
       if @thread
         while @queue.size>0 do
           dispatch()

--- a/lib/rutema/core/framework.rb
+++ b/lib/rutema/core/framework.rb
@@ -1,16 +1,77 @@
 module Rutema
+  #Represents the data beeing shunted between the components in lieu of logging.
+  #
+  #This is the primary type passed to the event reporters
+  class Message
+    attr_accessor :test,:text,:timestamp
+    #Keys used:
+    # test - the test id/name
+    # text - the text of the message
+    # timestamp
+    def initialize params
+      @test=params.fetch(:test,"")
+      @text=params.fetch(:text,"")
+      @timestamp=params.fetch(:timestamp,0)
+    end
+
+    def to_s
+      msg=""
+      msg<<"#{@test} " unless @test.empty?
+      msg<<@text
+      return msg
+    end
+  end
+
+  class ErrorMessage<Message
+    def to_s
+      msg="ERROR - "
+      msg<<"#{@test} " unless @test.empty?
+      msg<<@text
+      return msg
+    end
+  end
+
+  class RunnerMessage<Message
+    attr_accessor :duration,:status,:number,:out,:err
+    def initialize params
+      super(params)
+      @duration=params.fetch("duration",0)
+      @status=params.fetch("status",:none)
+      @number=params.fetch("number",1)
+      @out=params.fetch("out","")
+      @err=params.fetch("err","")
+    end
+
+    def to_s
+      msg="#{@test}:#{@number}"
+      msg<<" #{@text}." unless @text.empty?
+      outpt=output()
+      msg<<" Output:\n#{outpt}" unless outpt.empty?
+      return msg
+    end
+
+    def output
+      msg=""
+      msg<<"#{@out}\n" unless @out.empty?
+      msg<<@err unless @err.empty?
+      return msg
+    end
+  end
+
   module Messaging
     def error identifier,message
-      message(:test=>identifier,:error=>message)
+      @queue.push(ErrorMessage.new(:test=>identifier,:text=>message,:timestamp=>Time.now))
     end
     def message message
-      msg=message
-      if message.is_a?(String)
-        msg={:message=>message,:timestamp=>Time.now}
-      elsif message.is_a?(Hash)
-        msg[:timestamp]=Time.now
+      case message
+      when String
+        Message.new(:text=>message,:timestamp=>Time.now)
+      when Hash
+        hm=Message.new(message)
+        hm=RunnerMessage.new(message) if message[:test] && message["status"]
+        hm.timestamp=Time.now
+        @queue.push(hm)
       end
-      @queue.push(msg)
     end
   end
   #Generic error class for errors in the engine

--- a/lib/rutema/core/framework.rb
+++ b/lib/rutema/core/framework.rb
@@ -43,10 +43,10 @@ module Rutema
     end
 
     def to_s
-      msg="#{@test}:#{@number}"
-      msg<<" #{@text}." unless @text.empty?
+      msg="#{@test}:"
+      msg<<"#{@text}." unless @text.empty?
       outpt=output()
-      msg<<" Output:\n#{outpt}" unless outpt.empty?
+      msg<<" Output:\n#{outpt}" unless outpt.empty? || @status!=:error
       return msg
     end
 
@@ -54,7 +54,7 @@ module Rutema
       msg=""
       msg<<"#{@out}\n" unless @out.empty?
       msg<<@err unless @err.empty?
-      return msg
+      return msg.chomp
     end
   end
 

--- a/lib/rutema/core/runner.rb
+++ b/lib/rutema/core/runner.rb
@@ -20,14 +20,14 @@ module Rutema
         steps=[]
         status=:success
         state={'start_time'=>Time.now, "sequence_id"=>@number_of_runs,:test=>spec.name}
-        message(:test=>spec.name,'phase'=>'started')
+        message(:test=>spec.name,:text=>'started')
         if @setup
-          message(:test=>spec.name,'phase'=>'setup')
+          message(:test=>spec.name,:text=>'setup')
           executed_steps,status=run_scenario("_setup_",@setup.scenario,@context)
           steps+=executed_steps
         end
         if status!=:error
-          message(:test=>spec.name,'phase'=>'running')
+          message(:test=>spec.name,:text=>'running')
           executed_steps,status=run_scenario(spec.name,spec.scenario,@context)
           steps+=executed_steps
         else
@@ -35,10 +35,10 @@ module Rutema
         end
         state['status']=status
         if @teardown
-          message(:test=>spec.name,'phase'=>'teardown')
+          message(:test=>spec.name,:text=>'teardown')
           executed_steps,status=run_scenario("_teardown_",@teardown.scenario,@context)
         end
-        message(:test=>spec.name,'phase'=>'finished')
+        message(:test=>spec.name,:text=>'finished')
         state["stop_time"]=Time.now
         state['steps']=steps
         @number_of_runs+=1
@@ -56,7 +56,7 @@ module Rutema
             status=:error
           else
             stps.each do |s| 
-              message(:test=>name,:message=>s.to_s)
+              message(:test=>name,:text=>s.to_s)
               executed_steps<<run_step(s,meta)
               message(:test=>name,'number'=>s.number,'status'=>s.status,'out'=>s.output,'err'=>s.error,'duration'=>s.exec_time)
               status=s.status

--- a/lib/rutema/core/runner.rb
+++ b/lib/rutema/core/runner.rb
@@ -55,10 +55,9 @@ module Rutema
             error(name,"Scenario #{name} contains no steps")
             status=:error
           else
-            stps.each do |s| 
-              message(:test=>name,:text=>s.to_s)
+            stps.each do |s|
               executed_steps<<run_step(s,meta)
-              message(:test=>name,'number'=>s.number,'status'=>s.status,'out'=>s.output,'err'=>s.error,'duration'=>s.exec_time)
+              message(:test=>name,:text=>s.to_s,'number'=>s.number,'status'=>s.status,'out'=>s.output,'err'=>s.error,'duration'=>s.exec_time)
               status=s.status
               break if :error==s.status
             end

--- a/lib/rutema/parsers/xml.rb
+++ b/lib/rutema/parsers/xml.rb
@@ -43,6 +43,8 @@ module Rutema
           raise Rutema::ParserError,"Duplicate test name '#{spec.name}' in #{filename}" if @parsed.include?(spec.name)
           @parsed<<spec.name
           extension_handling(spec)
+        rescue REXML::ParseException
+          raise Rutema::ParserError,$!.message
         end
       end
       private

--- a/lib/rutema/version.rb
+++ b/lib/rutema/version.rb
@@ -3,7 +3,7 @@ module Rutema
   module Version
     MAJOR=2
     MINOR=0
-    TINY="0.pre5"
+    TINY="0.pre6"
     STRING=[ MAJOR, MINOR, TINY ].join( "." )
   end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -34,10 +34,10 @@ module TestRutema
     def test_rutema_configuration
       cfg="foo.cfg"
       File.expects(:read).with("full.rutema").returns(FULL_CONFIG)
-      File.expects(:exists?).with(File.expand_path("check.spec")).returns(true)
-      File.expects(:exists?).with(File.expand_path("teardown.spec")).returns(true)
-      File.expects(:exists?).with(File.expand_path("setup.spec")).returns(true)
-      File.expects(:exists?).with("T001.spec").returns(false)
+      File.expects(:exist?).with(File.expand_path("check.spec")).returns(true)
+      File.expects(:exist?).with(File.expand_path("teardown.spec")).returns(true)
+      File.expects(:exist?).with(File.expand_path("setup.spec")).returns(true)
+      File.expects(:exist?).with("T001.spec").returns(false)
       #load the valid configuration
       assert_nothing_raised() { cfg=Rutema::Configuration.new("full.rutema")}
       assert_not_nil(cfg.parser)

--- a/test/test_engine.rb
+++ b/test/test_engine.rb
@@ -55,10 +55,10 @@ module TestRutema
         engine=Rutema::Engine.new(conf)
         engine.run
       #end
-      assert_equal(9, MockReporter.updates)
+      assert_equal(5, MockReporter.updates)
       #test for a spec that is not in the config and re-entry
       assert_raise(Rutema::RutemaError) { engine.run("foo")}
-      assert_equal(2, MockReporter.updates)
+      assert_equal(1, MockReporter.updates)
     end
   end
 end

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -16,10 +16,10 @@ module TestRutema
       state=nil
       assert_nothing_raised() { state=runner.run(spec) }
       assert_equal(1, state["steps"].size)
-      assert_equal(6, queue.size)
-      assert_equal("started", queue.pop["phase"])
-      4.times{queue.pop}
-      assert_equal("finished", queue.pop["phase"])
+      assert_equal(4, queue.size)
+      assert_equal("started", queue.pop.text)
+      2.times{queue.pop}
+      assert_equal("finished", queue.pop.text)
     end
     
     def test_run_exceptions


### PR DESCRIPTION
A little bit of type safety when passing to the reporters is not a bad thing.