### PR TITLE
Typed collection for state data

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+== 2.0.0.pre10 /2016-03-21
+ * Typed collection for states in block reporters
 == 2.0.0.pre9 /2016-03-14
  * Bugfix: JUnit reporter works again
 == 2.0.0.pre8 /2016-03-09

--- a/lib/rutema/core/reporter.rb
+++ b/lib/rutema/core/reporter.rb
@@ -51,7 +51,9 @@ module Rutema
         end
       end
     end
-  
+    #This reporter is always instantiated and collects all messages fired by the rutema engine
+    #
+    #The collections of errors and states are then at the end of a run fed to the block reporters
     class Collector<EventReporter
       attr_reader :errors,:states
       def initialize params,dispatcher
@@ -75,7 +77,12 @@ module Rutema
         end
       end
     end
-
+    #A very simple event reporter that outputs to the console
+    #
+    #It has three settings: off, normal and verbose.
+    #
+    #Example configuration:
+    # cfg.reporter={:class=>Rutema::Reporters::Console, "mode"=>"verbose"}
     class Console<EventReporter
       def initialize configuration,dispatcher
         super(configuration,dispatcher)

--- a/lib/rutema/reporters/junit.rb
+++ b/lib/rutema/reporters/junit.rb
@@ -34,8 +34,8 @@ module Rutema
         total_duration=0
         states.each do |k,v|
           tests<<test_case(k,v)
-          number_of_failed+=1 if v['status']!=:success
-          total_duration+=v["duration"].to_f
+          number_of_failed+=1 if v.status!=:success
+          total_duration+=v.duration.to_f
         end
         #<testsuite disabled="0" errors="0" failures="1" hostname="" id=""
         #name="" package="" skipped="" tests="" time="" timestamp="">
@@ -59,17 +59,17 @@ module Rutema
         #  <error>       => test encountered an error
         #</testcase>
         element_test=REXML::Element.new("testcase")
-        element_test.add_attributes("name"=>name,"time"=>state["duration"],"classname"=>@configuration.context[:config_name])
-        if state['status']!=:success
+        element_test.add_attributes("name"=>name,"time"=>state.duration,"classname"=>@configuration.context[:config_name])
+        if state.status!=:success
           fail=REXML::Element.new("failure")
-          fail.add_attribute("message","Step #{state["steps"].last.number} failed.")
-          fail.add_text "Step #{state["steps"].last.number} failed."
+          fail.add_attribute("message","Step #{state.steps.last.number} failed.")
+          fail.add_text "Step #{state.steps.last.number} failed."
           element_test.add_element(fail)
           out=REXML::Element.new("system-out")
-          out.add_text state["steps"].last.out
+          out.add_text state.steps.last.out
           element_test.add_element(out)
           err=REXML::Element.new("system-err")
-          err.add_text state["steps"].last.err
+          err.add_text state.steps.last.err
           element_test.add_element(err)
         end
         return element_test

--- a/lib/rutema/version.rb
+++ b/lib/rutema/version.rb
@@ -3,7 +3,7 @@ module Rutema
   module Version
     MAJOR=2
     MINOR=0
-    TINY="0.pre9"
+    TINY="0.pre10"
     STRING=[ MAJOR, MINOR, TINY ].join( "." )
   end
 end

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -12,8 +12,14 @@ module TestRutema
       configuration.stubs(:context).returns({})
       dispatcher=mock()
       junit_reporter=Rutema::Reporters::JUnit.new(configuration,dispatcher)
-      assert_equal("<?xml version='1.0'?><testsuite errors='0' failures='0' tests='0' time='0'/>", junit_reporter.process_data([],[],[]))
-      assert_equal("<?xml version='1.0'?><testsuite errors='0' failures='0' tests='0' time='0.000157'><testcase name='_setup_' time='0.000157'/></testsuite>", junit_reporter.process_data([],{"_setup_"=>{"timestamp"=>Time.now, "duration"=>0.000157, "status"=>:success, "steps"=>[]}},[]))
+      assert_equal("<?xml version='1.0'?><testsuite errors='0' failures='0' tests='0' time='0'/>", junit_reporter.process_data([],{},[]))
+      
+      states={"_setup_"=>Rutema::ReportState.new(
+          Rutema::RunnerMessage.new({"timestamp"=>Time.now, "duration"=>0.000157, "status"=>:success, "steps"=>[]})
+        )
+      }
+
+      assert_equal("<?xml version='1.0'?><testsuite errors='0' failures='0' tests='0' time='0.000157'><testcase name='_setup_' time='0.000157'/></testsuite>", junit_reporter.process_data([],states,[]))
     end
   end
 end

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -21,5 +21,28 @@ module TestRutema
 
       assert_equal("<?xml version='1.0'?><testsuite errors='0' failures='0' tests='0' time='0.000157'><testcase name='_setup_' time='0.000157'/></testsuite>", junit_reporter.process_data([],states,[]))
     end
+
+    def test_summary
+      #Rutema::Utilities.expects(:write_file).returns("OK")
+      configuration = mock()
+      configuration.expects(:reporters).returns(configuration)
+      configuration.expects(:fetch).returns({:class=>Rutema::Reporters::JUnit,"filename"=>"rutema.junit.xml"})
+      configuration.stubs(:context).returns({})
+      dispatcher=mock()  
+
+      reporter=Rutema::Reporters::Summary.new(configuration,dispatcher)
+      assert_equal(0,reporter.report([],{},[]))
+      states={"_setup_"=>Rutema::ReportState.new(
+          Rutema::RunnerMessage.new({"timestamp"=>Time.now, "duration"=>0.000157, "status"=>:success, "steps"=>[]})
+        )
+      }
+      assert_equal(0,reporter.report([],states,[]))
+
+      states={"_setup_"=>Rutema::ReportState.new(
+          Rutema::RunnerMessage.new({"timestamp"=>Time.now, "duration"=>0.000157, "status"=>:error, "steps"=>[]})
+        )
+      }
+      assert_equal(1,reporter.report([],states,[]))
+    end
   end
 end


### PR DESCRIPTION
Makes it easier to document and check if the state collection passed to the block reporters is of a fixed type