### PR TITLE
Reporters will crash if test identifier is nil

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+== 2.0.0.pre12 /2016-04-14
+ * Fixed crash when test name was nil in all reporters
 == 2.0.0.pre11 /2016-04-14
  * Fixed crash in detecting failures in the junit reporter
 == 2.0.0.pre10 /2016-03-21

--- a/lib/rutema/core/framework.rb
+++ b/lib/rutema/core/framework.rb
@@ -10,6 +10,7 @@ module Rutema
     # timestamp
     def initialize params
       @test=params.fetch(:test,"")
+      @test||=""
       @text=params.fetch(:text,"")
       @timestamp=params.fetch(:timestamp,Time.now)
     end

--- a/lib/rutema/version.rb
+++ b/lib/rutema/version.rb
@@ -3,7 +3,7 @@ module Rutema
   module Version
     MAJOR=2
     MINOR=0
-    TINY="0.pre11"
+    TINY="0.pre12"
     STRING=[ MAJOR, MINOR, TINY ].join( "." )
   end
 end


### PR DESCRIPTION
The Rutema::Message did not initialise member variable correctly