### PR TITLE
ParserExeptions should be raised for any spec-file

### DIFF
--- a/lib/rutema/core/engine.rb
+++ b/lib/rutema/core/engine.rb
@@ -74,8 +74,7 @@ module Rutema
         @parser.parse_specification(spec_identifier)
       rescue Rutema::ParserError
         error(spec_identifier,$!.message)
-        raise Rutema::ParserError, "In #{spec_identifier}: #{$!.message}" if is_special?(spec_identifier)
-        nil
+        raise Rutema::ParserError, "In #{spec_identifier}: #{$!.message}"
       end
     end
     def parse_specials configuration

--- a/test/test_engine.rb
+++ b/test/test_engine.rb
@@ -42,13 +42,28 @@ module TestRutema
       assert_raise(Rutema::RutemaError){Rutema::Engine.new(conf)}
     end
 
-    def test_run
+    def test_parserError
       conf=OpenStruct.new(:parser=>{:class=>Rutema::Parsers::XML},
           :reporters=>{MockReporter=>{:class=>MockReporter}},
           :tools=>{},
           :paths=>{},
           :tests=>["#{File.expand_path(File.dirname(__FILE__))}/data/sample.spec",
             "#{File.expand_path(File.dirname(__FILE__))}/data/duplicate_name.spec"],
+          :context=>{})
+      engine=nil
+      assert_raise ::Rutema::ParserError do
+        engine=Rutema::Engine.new(conf)
+        engine.run
+      end
+      assert_equal(0, MockReporter.updates)
+    end
+
+    def test_run
+      conf=OpenStruct.new(:parser=>{:class=>Rutema::Parsers::XML},
+          :reporters=>{MockReporter=>{:class=>MockReporter}},
+          :tools=>{},
+          :paths=>{},
+          :tests=>["#{File.expand_path(File.dirname(__FILE__))}/data/sample.spec"],
           :context=>{})
       engine=nil
       #assert_nothing_raised() do 
@@ -60,5 +75,6 @@ module TestRutema
       assert_raise(Rutema::RutemaError) { engine.run("foo")}
       assert_equal(1, MockReporter.updates)
     end
+
   end
 end


### PR DESCRIPTION
otherwise one doesn't know what to fix if there's a typo in a spec file. All you see is that the test specified in the spec file is missing in the testsuite (if you notice that at all...)