### PR TITLE
Add RuboCop as development dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,35 @@
+---
+
+Metrics/AbcSize:
+  Max: 20
+Metrics/BlockLength:
+  Max: 120
+Layout/LineLength:
+  Max: 200
+Metrics/MethodLength:
+  Max: 25
+Style/AsciiComments:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+Style/NumericLiterals:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/RedundantReturn:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+AllCops:
+  Exclude:
+    - "out/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :development do
   gem "mocha", "~>1.12.0", :require => false
   gem "pry", "~>0.14.0", :require => false
   gem "rdoc", "~>6.3.0", :require => false
+  gem "rubocop", "~>1.12.0", :require => false
   gem "test-unit", "~>3.4.0", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     coderay (1.1.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -15,14 +16,32 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     mocha (1.12.0)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     patir (0.9.0)
       systemu (~> 2.6)
     power_assert (2.0.0)
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    rainbow (3.0.0)
     rake (13.0.3)
     rdoc (6.3.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.4)
+    rubocop (1.12.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -37,6 +56,7 @@ GEM
     thor (1.0.1)
     tins (1.24.1)
       sync
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -49,6 +69,7 @@ DEPENDENCIES
   patir (~> 0.8)
   pry (~> 0.14.0)
   rdoc (~> 6.3.0)
+  rubocop (~> 1.12.0)
   test-unit (~> 3.4.0)
 
 BUNDLED WITH


### PR DESCRIPTION
The configuration file represents the preferred defaults of damphyr.